### PR TITLE
docs(readme): add contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ npm run dev
 
 Open [http://localhost:3000/smite](http://localhost:3000/smite) with your browser to see the result.
 
+## Contributing
+
+### Conventional Commits
+
+This repository has switched to using the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) format for git commit messages.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:


### PR DESCRIPTION
Adds the `Contributing` section to the README
with a link to the Conventional Commits
specification website.

Refs: #18