### PR TITLE
fix(mobile): remove scrolling on no results

### DIFF
--- a/components/Main.tsx
+++ b/components/Main.tsx
@@ -20,6 +20,8 @@ import { SmiteGodCards } from "./SmiteGodCards";
 import { FilterDrawer } from "./FilterDrawer";
 
 const MainContainer = styled.main`
+  display: flex;
+  flex-direction: column;
   flex: 1;
 `;
 
@@ -49,7 +51,7 @@ export const Main = () => {
           </Toolbar>
         </Container>
       </AppBar>
-      <Box display="flex">
+      <Box display="flex" flex={1}>
         {!isSmallScreen && <FilterSidebar />}
         <SmiteGodCards />
       </Box>

--- a/components/SmiteGodCards.tsx
+++ b/components/SmiteGodCards.tsx
@@ -19,17 +19,17 @@ export const SmiteGodCards = () => {
   );
 
   return (
-    randomGods.length ? (
-      <Box
-        display="flex"
-        flex={1}
-        justifyContent="center"
-        marginTop={5}
-        flexWrap="wrap"
-        gap={5}
-        height="fit-content"
-      >
-        {randomGods.map((god) => (
+    <Box
+      display="flex"
+      flex={1}
+      justifyContent="center"
+      marginTop={5}
+      flexWrap="wrap"
+      gap={5}
+      height="fit-content"
+    >
+      {randomGods.length ? (
+        randomGods.map((god) => (
           <SmiteGodCard
             key={god.id}
             sx={{
@@ -53,19 +53,10 @@ export const SmiteGodCards = () => {
               </Typography>
             </CardContent>
           </SmiteGodCard>
-        ))}
-      </Box>
-    ) : (
-      <Container sx={{ height: 'calc(90vh - 64px)' }}>
-        <Box
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-          height="100%"
-        >
-          <Typography color="gray">No results found.</Typography>
-        </Box>
-      </Container>
-    )
+        ))
+      ) : (
+        <Typography color="gray">No results found.</Typography>
+      )}
+    </Box>
   );
 };


### PR DESCRIPTION
This was introduced when we calculate
height for the no results container.
We are switching to make the main element
flexbox to handle the height instead.

Refs: #22