### PR TITLE
build(jest): add coverage patterns and coverage thresholds

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -22,7 +22,16 @@ const config: Config = {
   collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  // collectCoverageFrom: undefined,
+  collectCoverageFrom: [
+    "api/**/*",
+    "components/**/*",
+    "hooks/**/*",
+    "pages/**/*",
+    "stores/**/*",
+    "styles/**/*",
+    "types/**/*",
+    "utils/**/*",
+  ],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: "coverage",
@@ -44,7 +53,14 @@ const config: Config = {
   // ],
 
   // An object that configures minimum threshold enforcement for coverage results
-  // coverageThreshold: undefined,
+  coverageThreshold: {
+    global: {
+      branches: 45,
+      functions: 15,
+      lines: 5,
+      statements: 5,
+    },
+  },
 
   // A path to a custom dependency extractor
   // dependencyExtractor: undefined,


### PR DESCRIPTION
Initially adding the jest coverage thresholds to ensure that we do not decrease in code coverage as we add new features. These thresholds will need to be updated as we continue to increase our test coverage with unit tests.